### PR TITLE
#385 Fix Application Crash

### DIFF
--- a/CompactGUI.Watcher/Watcher.vb
+++ b/CompactGUI.Watcher/Watcher.vb
@@ -210,7 +210,7 @@ Public Class WatchedFolder : Inherits ObservableObject
 
     Public ReadOnly Property DecayPercentage As Decimal
         Get
-            If LastCompressedSize = 0 Then Return 1
+            If LastCompressedSize = 0 Or LastCompressedSize - LastUncompressedSize = 0 Then Return 1
             Return Math.Clamp((LastCheckedSize - LastCompressedSize) / (LastUncompressedSize - LastCompressedSize), 0, 1)
         End Get
     End Property

--- a/CompactGUI/ViewModels/MainViewModel.vb
+++ b/CompactGUI/ViewModels/MainViewModel.vb
@@ -130,8 +130,14 @@ Public Class MainViewModel : Inherits ObservableObject
             .LastCompressedDate = DateTime.Now,
             .LastCheckedDate = DateTime.Now,
             .LastCheckedSize = ActiveFolder.CompressedBytes,
-            .LastSystemModifiedDate = DateTime.Now,
-            .CompressionLevel = ActiveFolder.AnalysisResults.Select(Function(f) f.CompressionMode).Max}
+            .LastSystemModifiedDate = DateTime.Now
+            }
+
+        If ActiveFolder.AnalysisResults IsNot Nothing AndAlso ActiveFolder.AnalysisResults.Any() Then
+            newWatched.CompressionLevel = ActiveFolder.AnalysisResults.Select(Function(f) f.CompressedSize).Max()
+        Else
+            newWatched.CompressionLevel = -2
+        End If
 
         Watcher.AddOrUpdateWatched(newWatched)
 


### PR DESCRIPTION
fix(MainViewModel.vb): Resolve crash when compressing an empty folder and adding it to the watcher
fix(Watcher.vb): Resolve crash when attempting to add an uncompressed folder to the watcher, which caused a division by 0 throw and subsequent crash

Closes #385 