### PR TITLE
Fix a few synchronization-related crashes

### DIFF
--- a/CompactGUI/Application.xaml.vb
+++ b/CompactGUI/Application.xaml.vb
@@ -39,7 +39,9 @@ Class Application
             Using client = New NamedPipeClientStream(".", "CompactGUI", PipeDirection.Out)
                 client.Connect()
                 Using writer = New StreamWriter(client)
-                    writer.WriteLine(e.Args(0))
+                    If e.Args.Length > 0 Then
+                        writer.WriteLine(e.Args(0))
+                    End If
                 End Using
             End Using
 

--- a/CompactGUI/Application.xaml.vb
+++ b/CompactGUI/Application.xaml.vb
@@ -13,8 +13,19 @@ Class Application
 
         SettingsHandler.InitialiseSettings()
 
+        Dim acquiredMutex As Boolean
 
-        If Not SettingsHandler.AppSettings.AllowMultiInstance AndAlso Not mutex.WaitOne(0, False) Then
+        Try
+            acquiredMutex = mutex.WaitOne(0, False)
+        Catch ex As AbandonedMutexException
+            ' This means the mutex was acquired successfully,
+            ' but its last owner exited abruptly, without releasing it.
+            ' acquiredMutex should still be True here, but further error checking
+            ' on shared program state could be added here as well.
+            acquiredMutex = True
+        End Try
+
+        If Not SettingsHandler.AppSettings.AllowMultiInstance AndAlso Not acquiredMutex Then
 
             If e.Args.Length <> 0 AndAlso e.Args(0) = "-tray" Then
                 MessageBox.Show("An instance of CompactGUI is already running")

--- a/CompactGUI/ViewModels/MainViewModel.vb
+++ b/CompactGUI/ViewModels/MainViewModel.vb
@@ -258,10 +258,19 @@ Public Class MainViewModel : Inherits ObservableObject
                 .Arguments = $"""{ActiveFolder.FolderName}""",
                 .Verb = "runas"}
         }
-        Application.mutex.Dispose()
-        myproc.Start()
-        Application.Current.Shutdown()
-
+        Dim app As Application = Application.Current
+        app.ShutdownPipeServer().ContinueWith(
+            Sub()
+                app.Dispatcher.Invoke(
+                    Sub()
+                        Application.mutex.ReleaseMutex()
+                        Application.mutex.Dispose()
+                    End Sub
+                )
+                myproc.Start()
+                app.Dispatcher.Invoke(Sub() app.Shutdown())
+            End Sub
+        )
     End Sub
 
 


### PR DESCRIPTION
# Instance Synchronization

This change fixes a few bugs related to synchronization between multiple application instances.

This is my first time working with .NET and with the Visual Basic language, so my bad if any parts of the implementations here are off!

## Fix for #413

`AbandonedMutexException`s are now (accurately) treated as successful mutex acquisitions, to prevent a crash loop. Any additional cleanup or scrutiny as to *why* a previous process exited abruptly is not implemented here.

## Fix for #414

The `NamedPipeServerStream` managed by `ProcessNextInstanceMessage` is now allowed to shut down gracefully before releasing the application mutex and restarting the process as an administrator, preventing a crash from opening too many server instances for the (unique) pipe simultaneously.

The `ProcessNextInstanceMessage` method has also been refactored to use async I/O rather than running in a background thread, since `WaitForConnectionAsync` was a convenient way to allow cancelling its loop anyway.

## Bonus Fix

The `NamedPipeClientStream` code was crashing with an index error when trying to re-summon an existing window without having any argument to pass to it, so that was also fixed.

## Extra Note: Remaining Errors

Shutting down the application at the end of the sequence to relaunch as an administrator still ends up crashing consistently with a `System.ArgumentOutOfRangeException` (somewhere in `System.Windows.Media.VisualCollection` as part of an incredibly opaque traceback), which terminates the application, which is mostly okay/invisible since it is supposed to shut down at that point anyway. This isn't a new error; it was present before the changes in this PR, and I wasn't sure how to fix it, so I didn't touch it.

It seems to happen solely from the call to `Application.Current.Shutdown()` in the `RunAsAdmin` method, even when all the other logic around opening the new process is completely stripped out, so I don't think these changes affect it either way. It also triggers the error if you replace `Application.Current.Shutdown()` with a call to just `Application.Current.MainWindow.Hide()` (or `.Close()`), so as a guess, it seems like the error might be related to some hooks on window visibility.