### PR TITLE
Fix: Correct file exclusion logic in Compactor

### DIFF
--- a/CompactGUI.Core.Tests/CompactGUI.Core.Tests.csproj
+++ b/CompactGUI.Core.Tests/CompactGUI.Core.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CompactGUI.Core\CompactGUI.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CompactGUI.Core.Tests/CompactorTests.cs
+++ b/CompactGUI.Core.Tests/CompactorTests.cs
@@ -1,0 +1,38 @@
+using Xunit;
+using CompactGUI.Core;
+using System.IO;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CompactGUI.Core.Tests
+{
+    public class CompactorTests
+    {
+        [Fact]
+        public async Task BuildWorkingFilesList_WithExclusion_ShouldExcludeCorrectFiles()
+        {
+            // Arrange
+            var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDir);
+            var file1 = Path.Combine(tempDir, "test.txt");
+            var file2 = Path.Combine(tempDir, "test.log");
+            File.WriteAllText(file1, "This is a test file.");
+            File.WriteAllText(file2, "This is a log file.");
+
+            var analyser = new Analyser(tempDir, null);
+            var compactor = new Compactor(tempDir, WOFCompressionAlgorithm.XPRESS4K, new[] { ".log" }, analyser, null);
+
+            // Act
+            var fileDetails = (FileDetails)await compactor.BuildWorkingFilesList();
+            var workingFiles = new List<FileDetails>(fileDetails);
+
+            // Assert
+            Assert.Single(workingFiles);
+            Assert.Equal(file1, workingFiles[0].FileName);
+
+            // Clean up
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/CompactGUI.Core/Compactor.cs
+++ b/CompactGUI.Core/Compactor.cs
@@ -132,7 +132,7 @@ public sealed class Compactor : ICompressor, IDisposable
             .Where(fl =>
                 fl.CompressionMode != wofCompressionAlgorithm
                 && fl.UncompressedSize > clusterSize
-                && ((fl.FileInfo != null && !excludedFileExtensions.Contains(fl.FileInfo.Extension)) || excludedFileExtensions.Contains(fl.FileName))
+                && fl.FileInfo != null && !excludedFileExtensions.Contains(fl.FileInfo.Extension)
             )
             .Select(fl => new FileDetails(fl.FileName, fl.UncompressedSize))
             .ToList();


### PR DESCRIPTION
The file exclusion logic in the BuildWorkingFilesList method was flawed. The condition incorrectly included files for compression if their full path was present in the exclusion list, which is intended for file extensions.

This change corrects the LINQ query to ensure that files are excluded based on their extension as intended. A new test project and test case have been added to verify this fix.